### PR TITLE
Added Application component unit tests.

### DIFF
--- a/test/unit/specs/Application.spec.js
+++ b/test/unit/specs/Application.spec.js
@@ -1,7 +1,58 @@
+import Vue from 'vue';
+import router from '@/router';
+import VueRouter from 'vue-router';
 import Application from '@/components/Application';
 
 describe('Application.vue', () => {
-  it('Data is a function', () => {
-    expect(Application.data).to.be.a('function');
+  // Nice little helper to return our component within a div
+  const getComponent = () => {
+    const Constructor = Vue.extend(Application);
+
+    return new Constructor({
+      router
+    }).$mount();
+  };
+
+  describe('Component', () => {
+    it('should have a property "name"', () => expect(Application.name).to.be.a('string'));
+
+    it('should have a property "name" set to "Application"', () => expect(Application.name).to.equal('Application'));
+
+    it('should have a data hook', () => expect(Application.data).to.be.a('function'));
+  });
+
+  describe('Template', () => {
+    Vue.use(VueRouter);
+
+    it('should mount correctly', () => {
+      const component = getComponent();
+
+      expect(component.$el);
+    });
+
+    it('should have a "div" element', () => {
+      const component = getComponent();
+
+      expect(component.$el.querySelector('div').length);
+    });
+
+    it('should have a "div" element with a "className" set to "app"', () => {
+      const component = getComponent();
+
+      expect(component.$el.className).to.equal('app');
+    });
+
+    it('should have a "nav" element', () => {
+      const component = getComponent();
+
+      expect(component.$el.querySelector('nav').length);
+    });
+
+    it('should have a "ul" element with 12 "li" elements', () => {
+      const component = getComponent();
+
+      expect(component.$el.querySelector('ul').length);
+      expect(component.$el.querySelectorAll('li').length).to.equal(12);
+    });
   });
 });


### PR DESCRIPTION
This component is very basic, so I just added some pretty basic stuff. 

However, I'm getting a warning that a Logout route is missing. Once this route has been added, these warnings will go away. See output below:

```
> lintol-frontend@1.0.0 unit /Users/seandelaney/Sites/lintol-frontend
> cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run

06 02 2018 17:29:10.877:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
06 02 2018 17:29:10.880:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
06 02 2018 17:29:10.905:INFO [launcher]: Starting browser PhantomJS
06 02 2018 17:29:11.835:INFO [PhantomJS 2.1.1 (Mac OS X 0.0.0)]: Connected on socket xZu4Tl2E87kHlPD6AAAA with id 17192170

  Application.vue
    Component
      ✓ should have a property "name"
      ✓ should have a property "name" set to "Application"
      ✓ should have a data hook
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
    Template
      ✓ should render correctly
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
      ✓ should have a "div" element
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
WARN LOG: '[vue-router] Route with name 'logout' does not exist'
      ✓ should has a "div" element with a "className" set to "app"

PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 6 of 6 SUCCESS (0.113 secs / 0.067 secs)
TOTAL: 6 SUCCESS


=============================== Coverage summary ===============================
Statements   : 14.29% ( 33/231 )
Branches     : 5.56% ( 1/18 )
Functions    : 0% ( 0/99 )
Lines        : 14.29% ( 33/231 )
================================================================================
seandelaney@SeanDelaneysMBP ~/Sites/lintol-frontend (unit-testing) $
```