### PR TITLE
Further UI improvements to match InVision

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ export default {
 @import 'assets/scss/application.scss';
 .sideOrangeBar {
   border-left: solid 35px $sideBar;
+  min-height: 100vh;
 }
 
 .whiteBox {
@@ -25,6 +26,7 @@ export default {
   width: 15px;	
   border: 3px solid #FFFFFF;
   box-sizing: border-box;
+  min-height: 100vh;
 }
 
 

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -8,7 +8,7 @@ $warningText: red;
 $sideBar: #F1592A;
 $rowBackground: #F9F9F9;
 $separatorColour: #E5E5E5;
-$bold: 500;
+$bold: 800;
 
 
 $orange: #F1592A;

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -9,6 +9,7 @@ $sideBar: #F1592A;
 $rowBackground: #F9F9F9;
 $separatorColour: #E5E5E5;
 $bold: 800;
+$grey: #777776;
 
 
 $orange: #F1592A;
@@ -16,8 +17,8 @@ $orangeDark: #AA6666;
 $greyFont: #BFBFBF;
 
 select {
-  border: 1px solid #777776;;
-  color: #777776;;
+  border: 1px solid $grey;
+  color: $grey;
   border-radius: 4px;
   font-size: 0.625em;
 }

--- a/src/components/Application.vue
+++ b/src/components/Application.vue
@@ -34,6 +34,7 @@ export default {
 }
 
 .menu {
+  min-height: 100vh;
 }
 
 .panel {

--- a/src/components/Application.vue
+++ b/src/components/Application.vue
@@ -31,11 +31,9 @@ export default {
   flex-direction: row;
   flex-wrap: nowrap; 
   height: 100%;
-  height: 100vh;
 }
 
 .menu {
-  height: 100%;
 }
 
 .panel {

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -180,7 +180,7 @@ export default {
     > label {
       margin: 0px 10px;
       font-size: 0.75em;
-      color: #777776;
+      color: $grey;
       cursor: pointer;
     }
   }

--- a/src/components/profiles/ProfileRow.vue
+++ b/src/components/profiles/ProfileRow.vue
@@ -143,6 +143,6 @@ div .profileColumn p {
 
 .user {
   font-size: 0.75em;
-  color: #777776;
+  color: $grey;
 }
 </style>

--- a/src/components/reports/reportview/ListReportView.vue
+++ b/src/components/reports/reportview/ListReportView.vue
@@ -153,7 +153,7 @@ export default {
 
 .issueCount {
   font-size: 24px;
-  color: #777776;
+  color: $grey;
   vertical-align: middle;
 }
 

--- a/src/components/reports/reportview/ReportListItem.vue
+++ b/src/components/reports/reportview/ReportListItem.vue
@@ -81,14 +81,14 @@ export default {
 }
 
 .issueType {
-  color: #777776;
+  color: $grey;
   font-weight: bold;
   flex: 0.5;
   margin-right: 10px;
 }
 
 .issueDescription {
-  color: #777776;
+  color: $grey;
   flex: 2;
 }
 

--- a/src/components/reports/reportview/exception/ExceptionDetails.vue
+++ b/src/components/reports/reportview/exception/ExceptionDetails.vue
@@ -57,7 +57,7 @@ export default {
 
 .itemType {
   font-size: 12px;
-  color: #777776;
+  color: $grey;
   font-weight: bold;
 }
 

--- a/src/components/reports/reportview/map/MapDetails.vue
+++ b/src/components/reports/reportview/map/MapDetails.vue
@@ -105,7 +105,7 @@ export default {
 
 .itemType {
   font-size: 12px;
-  color: #777776;
+  color: $grey;
   font-weight: bold;
 }
 

--- a/src/components/reports/reportview/map/MapMarkerDetail.vue
+++ b/src/components/reports/reportview/map/MapMarkerDetail.vue
@@ -51,11 +51,11 @@ export default {
 }
 
 .issueType {
-  color: #777776;
+  color: $grey;
   font-weight: bold;
 }
 
 .issueDescription {
-  color: #777776;
+  color: $grey;
 }
 </style>

--- a/src/components/reports/reportview/tabular/TabularDetails.vue
+++ b/src/components/reports/reportview/tabular/TabularDetails.vue
@@ -69,7 +69,7 @@ export default {
 
 .itemType {
   font-size: 12px;
-  color: #777776;
+  color: $grey;
   font-weight: bold;
 }
 

--- a/src/components/resources/AddResourceBlock.vue
+++ b/src/components/resources/AddResourceBlock.vue
@@ -160,7 +160,7 @@ export default {
 }
 
 .newResource {
-  color: #777776;
+  color: $grey;
   font-size: 0.6875em;
   text-decoration: underline;
   font-weight: $bold;

--- a/src/components/resources/ResourceRow.vue
+++ b/src/components/resources/ResourceRow.vue
@@ -136,7 +136,7 @@ label {
 }
 
 .archivedStatus {
-  background-color: #777776;
+  background-color: $grey;
 }
 
 .validLinkStatus {

--- a/src/components/resources/ResourceRow.vue
+++ b/src/components/resources/ResourceRow.vue
@@ -124,11 +124,11 @@ label {
 }
 
 .newStatus {
-  background-color: blue;
+  background-color: #0070E0;
 }
 
 .invalidStatus {
-  background-color: purple;
+  background-color: #FF4E50;
 }
 
 .runStatus {
@@ -191,7 +191,8 @@ label {
   color: $orange;
   border: 2px solid $orange;
   border-radius: 5px;
-  font-size: 0.65em;
+  font-size: 0.75em;
+  padding: 3px;
   -webkit-appearance: none;
   -moz-appearance: none;
   cursor: pointer;

--- a/src/components/resources/ResourceTable.vue
+++ b/src/components/resources/ResourceTable.vue
@@ -263,14 +263,16 @@ export default {
  
 .arrowDown:after {
   content: '\2193';
-  font-size: 18px;
-  font-weight: $bold;
+  font-size: 12px;
+  font-weight: 1000;
+  color: $grey;
 }
 
 .arrowUp:after {
   content: '\2191';
-  font-size: 18px;
-  font-weight: $bold;
+  font-size: 12px;
+  font-weight: 1000;
+  color: $grey;
 }
 
 .actionContainer {

--- a/src/components/resources/ResourceTable.vue
+++ b/src/components/resources/ResourceTable.vue
@@ -263,13 +263,13 @@ export default {
  
 .arrowDown:after {
   content: '\2193';
-  font-size: 12px;
+  font-size: 18px;
   font-weight: $bold;
 }
 
 .arrowUp:after {
   content: '\2191';
-  font-size: 12px;
+  font-size: 18px;
   font-weight: $bold;
 }
 

--- a/src/components/resources/table.scss
+++ b/src/components/resources/table.scss
@@ -112,7 +112,7 @@ $filenameMaxWidth: 130px;
       text-transform: uppercase;
       margin-top: 4px;
       color: grey;
-      font-size: 0.6875em;
+      font-size: 0.75em;
     }
   }
 }

--- a/src/components/users/UserComponent.vue
+++ b/src/components/users/UserComponent.vue
@@ -27,7 +27,7 @@ export default {
 
 label {
   font-size: 0.75em;
-  color: #777776;
+  color: $grey;
   margin-bottom: 0px;
 }
 


### PR DESCRIPTION
This PR has the following effects:

* make sure left-hand orange and grey bars reach the bottom of the screen or page, whichever is lower
* the font-weight is heavier in bold
* status colors match the design's hex codes
* /View Resource/ labels are slightly larger
* sorting arrows are grey (#46)
* default table font is slightly larger
* `#777776` is now `$grey` 